### PR TITLE
start script improvments

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,11 +1,17 @@
 {
 	"configurations": [
 		{
-			"name": "Miniflare (npm)",
+			"name": "Miniflare (launch)",
 			"type": "node",
 			"request": "launch",
 			"runtimeExecutable": "npm",
-			"runtimeArgs": ["run", "start:local"], 
+			"runtimeArgs": ["run", "start"], 
+			"skipFiles": ["<node_internals>/**"],
+		},
+		{
+			"name": "Miniflare (attach)",
+			"type": "node",
+			"request": "attach",
 			"skipFiles": ["<node_internals>/**"]
 		}
 	]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,6 +49,10 @@
       "script": "test.watch",
       "isBackground": true,
       "problemMatcher": []
-    }
+    },
+		{
+			"type": "npm",
+			"script": "kill",
+		}
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "authly": "^2.0.1",
+        "cloudly-formdata": "^0.0.8",
         "cloudly-http": "^0.0.50",
         "cloudly-router": "^0.0.24",
         "gracely": "^2.0.3"
@@ -2480,6 +2481,11 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/cloudly-formdata": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/cloudly-formdata/-/cloudly-formdata-0.0.8.tgz",
+      "integrity": "sha512-vbhHGbtvPK9L7+ttS8TmDJsmr0bPuFIFg2Kc2LibAMOB9JKxRq1P/BdR8ELhkwfKKdXTa6IpkYAYEa0cAzXDHQ=="
     },
     "node_modules/cloudly-http": {
       "version": "0.0.50",
@@ -9195,6 +9201,11 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true
+    },
+    "cloudly-formdata": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/cloudly-formdata/-/cloudly-formdata-0.0.8.tgz",
+      "integrity": "sha512-vbhHGbtvPK9L7+ttS8TmDJsmr0bPuFIFg2Kc2LibAMOB9JKxRq1P/BdR8ELhkwfKKdXTa6IpkYAYEa0cAzXDHQ=="
     },
     "cloudly-http": {
       "version": "0.0.50",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/utily/worker-template/issues"
   },
   "homepage": "https://github.com/utily",
-  "main": "dist/index.mjs",
+  "main": "dist/_worker.js",
   "typings": "dist/index.d.ts",
   "type": "module",
   "git": {
@@ -49,13 +49,15 @@
     "lint": "eslint --max-warnings=0 '**/*.{ts,tsx}'",
     "fix": "eslint '**/*.{ts,tsx}' --fix",
     "build": "rollup -c",
+    "build:local": "rollup --config rollup.dev.config.js",
     "dev": "NODE_ENV=development npm run build",
     "test": "jest",
     "transpile": "tsc --project tsconfig.test.json",
     "deploy": "wrangler login && wrangler publish; wrangler logout",
     "login": "wrangler login",
-    "start": "wrangler dev rollup--env development",
-    "start:local": "rollup -c --watch & miniflare dist/index.mjs --watch --live-reload -B \"\" && kill $!",
+    "start": "(rollup --config rollup.dev.config.js --watch) & (node --experimental-vm-modules --inspect ./node_modules/miniflare/dist/src/cli.js dist/_worker.js --wrangler-env miniflare --watch --live-reload -B 'while [ ! -f dist/_worker.js ]; do sleep 0.1; done' && kill $!)",
+    "start:wrangler": "wrangler dev --env wrangler",
+		"kill": "(grep port wrangler.toml | awk '{print $3}' | xargs -i lsof -i :{} | awk '{if (NR!=1) {print $2}}' | xargs kill 2>/dev/null) && (ps -aux | grep rollup | grep watch | awk '{print $2}' | xargs kill 2>/dev/null)",
     "clean": "rimraf dist node_modules coverage"
   },
   "devDependencies": {
@@ -83,6 +85,7 @@
   },
   "dependencies": {
     "authly": "^2.0.1",
+    "cloudly-formdata": "^0.0.8",
     "cloudly-http": "^0.0.50",
     "cloudly-router": "^0.0.24",
     "gracely": "^2.0.3"

--- a/rollup.dev.config.js
+++ b/rollup.dev.config.js
@@ -1,0 +1,27 @@
+// plugin-node-resolve and plugin-commonjs are required for a rollup bundled project
+// to resolve dependencies from node_modules. See the documentation for these plugins
+// for more details.
+import { nodeResolve } from "@rollup/plugin-node-resolve"
+import commonjs from "@rollup/plugin-commonjs"
+import typescript from "@rollup/plugin-typescript"
+import json from "@rollup/plugin-json"
+import path from "path"
+
+export default {
+  input: "index.ts",
+  output: {
+    exports: "named",
+    format: "es",
+    file: "dist/_worker.js",
+    sourcemap: true,
+		sourcemapPathTransform: relativeSourcePath => path.resolve(__dirname, relativeSourcePath.replace(/^(..\/)+/, "")),
+  },
+  plugins: [commonjs(), nodeResolve({ browser: true }), typescript({ resolveJsonModule: true }), json()],
+	watch: {
+		clearScreen: false,
+	},
+	onwarn: warning => {
+		if ( warning.code !== 'THIS_IS_UNDEFINED' )
+			console.warn( warning.message );
+	},
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,16 +6,26 @@ zone_id = "abcdefg01234567890"
 workers_dev = true
 routes = ["https://example.com/item*"]
 vars = { }
+port = 8787
 
 [build]
 command = "npm install && npm run build"
+
 [build.upload]
 format = "modules"
-main = "./index.mjs"
+main = "./_worker.js"
 
-[env.development]
-	workers_dev = true
-	account_id = "abcdefg01234567890"
-	vars = {  }
-[dev]
-	port = 8999
+[env.wrangler]
+workers_dev = true
+account_id = "abcdefg01234567890"
+vars = {  }
+
+[env.miniflare]
+vars = { }
+durable_objects.bindings = [
+
+]
+
+[miniflare]
+durable_objects_persist = "./.miniflare/durable-objects/"
+kv_persist = "./.miniflare/kv/"


### PR DESCRIPTION
* added missing dependency to `cloudly-formdata`.
* start script does not crash if no initial build exists.
* added kill command to kill lingering processes.
* start script now launches miniflare instead of wrangler
* added start:wrangler to start wrangler 
* added `rollup.dev.config.js` for local builds so terser does not mess up the break points.
* added attach debugger as an option to launch.
* changed bundle file name from `index.mjs` to `_worker.js` to make it compatible with pages.