### PR TITLE
Minor wrangler patch.

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,6 @@ main = "./dist/_worker.js"
 
 [build]
 command = "npm install && npm run build"
-upload.format = "modules"
 
 [env.production]
 workers_dev = false


### PR DESCRIPTION
 - Deprecation: "build.upload.format": The format is inferred automatically from the code.