### PR TITLE
Removed build.upload.format

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-compatibility_date = "2022-11-25"
+compatibility_date = "2023-01-11"
 name = "worker-template"
 workers_dev = true
 routes = []
@@ -8,7 +8,6 @@ main = "./dist/_worker.js"
 
 [build]
 command = "npm install && npm run build"
-upload.format = "modules"
 
 [env.production]
 workers_dev = false


### PR DESCRIPTION
Output from Cloudflare:
you can remove this section.
    - Deprecation: "build.upload.format":
      The format is inferred automatically from the code.