### PR TITLE
Updated to cloudflare/wrangler-action@2.0.0 for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
         env:
-          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Install
         run: npm install
       - name: Deploy
-        uses: cloudflare/wrangler-action@1.3.0
+        uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
         env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}


### PR DESCRIPTION
Cloudflare has changed name of env-variable to CLOUDFLARE_ACCOUNT_ID
~~I also changed the name of the GitHub-variable to match.~~
Name of Github-variables is unchanged: ( `secrets.CF_API_TOKEN` & `secrets.CF_ACCOUNT_ID` )

![image](https://user-images.githubusercontent.com/10186207/211743408-5269fbef-2787-4ae9-8b8f-3b0b60121460.png)
